### PR TITLE
Add maven-compiler-plugin to compile for Java 7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,20 @@
         </repository>
     </repositories>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.1</version>
+                <configuration>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
         <dependency>
             <groupId>org.spongepowered</groupId>


### PR DESCRIPTION
`mvn package` failed to compile on my system due to an error about the diamond operator not being supported with -source 1.5:

```
[INFO] Compiling 5 source files to /Users/admin/minecraft/AccountAPISponge/target/classes
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] /Users/admin/minecraft/AccountAPISponge/src/main/java/com/frogocomics/api/account/AccountBuilder.java:[16,55] error: diamond operator is not supported in -source 1.5
[INFO] 1 error
[INFO] -------------------------------------------------------------
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 7.643s
[INFO] Finished at: Tue Apr 21 19:13:13 PDT 2015
[INFO] Final Memory: 9M/245M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:2.3.2:compile (default-compile) on project greenfield-api: Compilation failure
[ERROR] /Users/admin/minecraft/AccountAPISponge/src/main/java/com/frogocomics/api/account/AccountBuilder.java:[16,55] error: diamond operator is not supported in -source 1.5
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException

```

Updated the Maven pom.xml file to target compiling against Java 7, fixes this compilation error
